### PR TITLE
docs: update README for edit link protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to the "markdown-folder-links" extension will be documented 
 ### Initial Release
 - Added support for `folder://` protocol to open folders/files
 - Added support for `reveal://` protocol to reveal items in file manager
-- Added support for `vscode://file/` protocol to open in VSCode
-- Implemented wiki-style `[[folder:path]]` syntax
+- Added support for `edit://` protocol to open paths in VSCode
+- Implemented wiki-style `[[folder:path]]`, `[[reveal:path]]`, and `[[edit:path]]` syntax
 - Added hover previews with file/folder information
 - Path expansion for `~` and relative paths
 - Cross-platform support (macOS, Windows, Linux)

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ A VSCode extension that makes local folder and file paths clickable in Markdown 
 - 📁 **Multiple protocols** for different actions:
   - `folder://` - Opens the folder/file in your system's file manager
   - `reveal://` - Reveals the folder/file in the file manager (shows in parent directory)
-  - `vscode://file/` - Opens the folder in VSCode
+  - `edit://` - Opens the path in VSCode, creating files if needed
+- 📝 **Wiki-style links** - Use `[[folder:path]]`, `[[reveal:path]]`, or `[[edit:path]]`
 - 🏠 **Path expansion** - Supports `~` for home directory and relative paths
 - 👁️ **Hover preview** - See if paths exist and get file/folder information
-- ⚠️ **Smart handling** - Prompts to create non-existent folders
+- ⚠️ **Smart handling** - Prompts to create missing folders and creates files for `edit://` links
 - 🖥️ **Cross-platform** - Works on macOS, Windows, and Linux
 
 ## Usage
@@ -23,7 +24,7 @@ Standard markdown link format:
 ```markdown
 [Open Documents](folder://~/Documents)
 [Reveal in Finder](reveal://~/Downloads/file.pdf)
-[Open in VSCode](vscode://file//Users/name/Projects/my-project)
+[Open in VSCode](edit://~/Projects/my-project)
 ```
 
 Wiki-style double brackets:
@@ -31,6 +32,7 @@ Wiki-style double brackets:
 ```markdown
 [[folder:~/Documents]]
 [[reveal:~/Downloads/file.pdf]]
+[[edit:~/Projects/my-app]]
 ```
 
 ### Path Formats


### PR DESCRIPTION
## Summary
- document the `edit://` protocol for opening paths in VSCode
- clarify smart handling behavior and wiki-style link support
- fix changelog to match current protocols

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_68baeaf7c9848332a4662ac88e708817